### PR TITLE
Support running smach_viewer.py from ROS *.launch file

### DIFF
--- a/smach_viewer/scripts/smach_viewer.py
+++ b/smach_viewer/scripts/smach_viewer.py
@@ -1054,6 +1054,11 @@ def main():
     app.MainLoop()
 
 if __name__ == '__main__':
+    ros_node_name = 'smach_viewer'                  # backwards compatibility
+    if (len(sys.argv) > 2):                         # if run from ROS *.launch file
+        ros_node_name = sys.argv[-2].split('=')[1]  # allows user to send -f prefix in *.launch file
+        del sys.argv[-2:]                           #   (note: autofocus causes HEARTBEAT bug)
+        
     rospy.init_node('smach_viewer',anonymous=False, disable_signals=True,log_level=rospy.INFO)
 
     main()


### PR DESCRIPTION
Allows user to launch smach_viewer.py node(s) from a ROS *.launch file, e.g:
`<node name="smach_viewer_1" pkg="smach_viewer" type="smach_viewer.py" launch-prefix="xterm -e"/> `
`<node name="smach_viewer_2" pkg="smach_viewer" type="smach_viewer.py" launch-prefix="xterm -e"/> `

User can still run smach_viewer as previously using rosrun with cmd line arguments, e.g:
`$ rosrun smach_viewer smach_viewer.py -f`

Only problem is if you try to launch smach_viewer via roslaunch with an argument, e.g:
`<node name="smach_viewer_2" pkg="smach_viewer" type="smach_viewer.py" launch-prefix="xterm -e" args="-f"/> `
it will develop the HEARBEAT bug

Did this so I could view multiple FSMs simultaneously. One other alternative would be simply changing
ln 1062 to `rospy.init_node(ros_node_name,anonymous=True,disable_signals=True,log_level=rospy.INFO)`